### PR TITLE
Atualização com separações de ambientes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Configurações do Banco (Postgres)
+POSTGRES_USER=mytaskshub-admin
+POSTGRES_PASSWORD=senha123
+POSTGRES_DB=mytaskshub
+
+# Configurações do Backend
+DATABASE_URL="postgresql://mytaskshub-admin:senha123@localhost:5432/mytaskshub"
+PORT=3000
+JWT_SECRET=sua-chave-secreta-de-256-caracteres
+FRONTEND_URL="http://localhost:5173"
+
+# Configurações do frontend
+VITE_BACKEND_API_URL="http://localhost:3000/api"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Hackaton - Plataforma de Estudos (Kizathon)
 
-Esta é uma plataforma completa de gerenciamento de estudos e tarefas, desenvolvida para ajudar estudantes a manterem o foco e a organização. O projeto consiste em uma API robusta em Node.js e uma interface moderna e intuitiva em React.
+Esta é uma plataforma completa de gerenciamento de estudos e tarefas, desenvolvida para ajudar estudantes a manterem o foco e a organização. O projeto consiste em uma API robusta em Node.js e uma interface moderna e intuitiva em React. A aplicação foi separada pensando em dois ambientes, um de desenvolvimento e outro de produção.
+
+Cada componente, tanto o **backend** quanto o **frontend**, são possíveis testá-los isoladamente e em cada uma de suas pastas conterá um arquivo **`docker-compose.yml`** que servirá para subir o ambiente na forma de **desenvolvimento**.
+
+No repositório raiz contém dois arquivos **docker-compose**, o **`docker-compose.yml`** é utilizado para subir o ambiente em forma de produção, já o **`docker-compose.dev.yml`** é para subir todo o ambiente em forma de desenvolvimento. Mais abaixo tem instruções de como subir cada um dos ambientes.
 
 ## 🚀 Visão Geral do Projeto
 
@@ -29,9 +33,12 @@ A aplicação permite que usuários se cadastrem, façam login e gerenciem suas 
 
 ```text
 Hackaton-plataforma-de-estudos/
-├── backend/          # API REST, Prisma e Configurações de Banco
-├── frontend/         # Aplicação React e Assets
-└── README.md         # Documentação Geral (este arquivo)
+├── backend/               # API REST, Prisma e Configurações de Banco
+├── frontend/              # Aplicação React e Assets
+├── .env.example           # Arquivo .env contendo as principais variáveis de ambientes
+├── docker-compose.yml     # Arquivo docker que sobe o ambiente para produção
+├── docker-compose.dev.yml # Arquivo docker que sobe o ambiente para desenvolvimento
+└── README.md              # Documentação Geral (este arquivo)
 ```
 
 ---
@@ -40,19 +47,42 @@ Hackaton-plataforma-de-estudos/
 
 ### 1. Clonar o repositório
 ```bash
-git clone <url-do-repositorio>
+git clone https://github.com/NBnY5A/Hackaton-plataforma-de-estudos.git
 cd Hackaton-plataforma-de-estudos
 ```
 
-### 2. Configuração do Backend
+### 2. Rodar a aplicação via docker
+
+Para rodar a aplicação no modo de **desenvolvimento** utilize o comando abaixo:
+
+```bash
+docker-compose -f "docker-compose.dev.yml" up -d --build
+```
+
+Para rodar a aplicação no modo de **produção** utilize o comando abaixo:
+
+```bash
+docker-compose up -d --build
+```
+
+Caso opte por rodar as aplicações localmente, é possível também. Abaixo tem a explicação de como rodar localmente
+
+### 3. Configuração do Backend (sem docker)
+
+Para informações mais detalhadas de como rodar o backend, clique [aqui](backend/README.md)
+
 1. Entre na pasta: `cd backend`
 2. Instale as dependências: `npm install`
 3. Suba o banco de dados com Docker: `docker-compose up -d`
 4. Configure o arquivo `.env`:
    ```env
+   POSTGRES_USER=teste
+   POSTGRES_PASSWORD=teste
+   POSTGRES_DB=teste
    DATABASE_URL="postgresql://teste:teste@localhost:5432/teste"
    PORT=3000
-   JWT_SECRET=sua_chave_secreta_aqui
+   JWT_SECRET=sua-chave-secreta-de-256-caracteres
+   FRONTEND_URL="http://localhost:5173"
    ```
 5. Rode as migrations e gere o cliente Prisma:
    ```bash
@@ -61,12 +91,15 @@ cd Hackaton-plataforma-de-estudos
    ```
 6. Inicie o servidor: `npm run dev`
 
-### 3. Configuração do Frontend
+### 4. Configuração do Frontend (sem docker)
+
+Para informações mais detalhadas de como rodar o frontend, clique [aqui](frontend/README.md)
+
 1. Em um novo terminal, entre na pasta: `cd frontend`
 2. Instale as dependências: `npm install`
 3. Configure o arquivo `.env`:
    ```env
-   BACKEND_API_URL=http://localhost:3000/api
+   VITE_BACKEND_API_URL=http://localhost:3000/api
    ```
 4. Inicie a aplicação: `npm run dev`
 5. Acesse: `http://localhost:5173`

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,10 @@
+# Configurações do Banco (Postgres)
+POSTGRES_USER=mytaskshub-admin
+POSTGRES_PASSWORD=senha123
+POSTGRES_DB=mytaskshub
+
+# Configurações do Backend
+DATABASE_URL="postgresql://mytaskshub-admin:senha123@localhost:5432/mytaskshub"
+PORT=3000
+JWT_SECRET=sua-chave-secreta-de-256-caracteres
+FRONTEND_URL="http://localhost:5173"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:20-alpine AS builder
+
+RUN apk add --no-cache python3 make g++
+
+WORKDIR /usr/app
+
+ENV NODE_ENV=production
+
+COPY package*.json ./
+
+COPY prisma ./prisma/
+
+RUN npm install
+
+COPY . .
+
+RUN npx prisma generate
+
+EXPOSE 3000
+
+CMD [ "node", "src/app.js" ]

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,0 +1,21 @@
+FROM node:20-alpine
+
+RUN apk add --no-cache python3 make g++
+
+WORKDIR /usr/app
+
+COPY package*.json ./
+
+COPY prisma ./prisma/
+
+RUN npm install
+
+COPY . .
+
+RUN npx prisma generate
+
+ENV NODE_ENV=development
+
+EXPOSE 3000
+
+CMD [ "npm", "run", "dev" ]

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,6 +1,6 @@
 # Node.js Kizathon (Backend)
 
-Esta é a API backend para a plataforma de estudos do kizathon, construída para integração com frontend.
+Esta é a API backend para a plataforma de estudos do kizathon, construída para integração com frontend. Você pode optar por rodar o backend isoladamente via docker ou ambiente local, logo abaixo tem instruções de como você pode rodar das duas formas.
 
 ## Stack Tecnológica
 
@@ -13,7 +13,7 @@ Esta é a API backend para a plataforma de estudos do kizathon, construída para
 
 ---
 
-## Como rodar o projeto
+## Como rodar o backend localmente
 
 1. **Instalar dependências:**
    ```bash
@@ -22,15 +22,20 @@ Esta é a API backend para a plataforma de estudos do kizathon, construída para
 
 2. **Subir o Banco de Dados (Docker):**
    ```bash
-   docker-compose up -d
+   docker-compose up -d postgres
    ```
 
 3. **Configurar Variáveis de Ambiente:**
-   Crie um arquivo `.env` na raiz com as seguintes chaves:
+   Copie o arquivo `.env.example` e renomeie-o para `.env`, abaixo está um exemplo de como devem ficar suas variáveis de ambiente:
    ```env
+   POSTGRES_USER=teste
+   POSTGRES_PASSWORD=teste
+   POSTGRES_DB=teste
+
    DATABASE_URL="postgresql://teste:teste@localhost:5432/teste"
    PORT=3000
    JWT_SECRET=sua_chave_secreta_aqui
+   FRONTEND_URL="http://localhost:5173"
    ```
 
 4. **Sincronizar Banco e Gerar Prisma Client:**
@@ -45,6 +50,14 @@ Esta é a API backend para a plataforma de estudos do kizathon, construída para
    ```
 
 ---
+
+## 🚀 Como rodar o backend via docker
+
+Com o docker iniciado e na pasta **`backend`**, basta apenas rodar o comando abaixo: 
+
+```bash
+docker-compose up -d
+```
 
 ## Autenticação (Guia para Frontend)
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     container_name: mytaskshub-backend
     environment:
       DATABASE_URL: ${DATABASE_URL:-postgresql://mytaskshub-admin:senha123@mytaskshub-db:5432/mytaskshub}
+      FRONTEND_URL: ${FRONTEND_URL:-http://localhost:5173}
       JWT_SECRET: ${JWT_SECRET:-sua-chave-secreta-de-256-caracteres}
     build:
       context: .

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,15 +1,40 @@
 services:
   postgres:
     image: postgres:16-alpine
-    container_name: postgres
+    container_name: mytaskshub-db
     environment:
-      POSTGRES_USER: teste
-      POSTGRES_PASSWORD: teste
-      POSTGRES_DB: teste
+      POSTGRES_USER: ${POSTGRES_USER:-mytaskshub-admin}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-senha123}
+      POSTGRES_DB: ${POSTGRES_DB:-mytaskshub}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U mytaskshub-admin -d mytaskshub"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
     ports:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+
+  backend:
+    image: mytaskshub-backend:1.0
+    container_name: mytaskshub-backend
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgresql://mytaskshub-admin:senha123@mytaskshub-db:5432/mytaskshub}
+      JWT_SECRET: ${JWT_SECRET:-sua-chave-secreta-de-256-caracteres}
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/usr/app
+      - /usr/app/node_modules
+    command: sh -c "npx prisma db push && npm run dev"
+
 
 volumes:
   postgres_data:

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -8,7 +8,7 @@ import authRoutes from "./routes/auth.route.js";
 const app = express();
 
 app.use(cors({
-    origin: process.env.FRONTEND_URL || "http://localhost:5173",
+    origin: process.env.FRONTEND_URL,
 }));
 
 app.use(express.json());

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,55 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: mytaskshub-db
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-mytaskshub-admin}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-senha123}
+      POSTGRES_DB: ${POSTGRES_DB:-mytaskshub}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U mytaskshub-admin -d mytaskshub"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  frontend:
+    image: mytaskshub-frontend:1.0
+    container_name: mytaskshub-frontend
+    environment:
+      - VITE_BACKEND_API_URL=${VITE_BACKEND_API_URL:-http://localhost:3000/api}
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.dev
+    volumes:
+      - ./frontend:/usr/app           
+      - /usr/app/node_modules 
+    ports:
+      - "5173:5173"
+
+  backend:
+    image: mytaskshub-backend:1.0
+    container_name: mytaskshub-backend
+    environment:
+      DATABASE_URL: ${DATABASE_URL:-postgresql://mytaskshub-admin:senha123@mytaskshub-db:5432/mytaskshub}
+      FRONTEND_URL: ${FRONTEND_URL:-http://localhost:5173}
+      JWT_SECRET: ${JWT_SECRET:-sua-chave-secreta-de-256-caracteres}
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.dev
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./backend:/usr/app
+      - /usr/app/node_modules
+    command: sh -c "npx prisma db push && npm run dev"
+
+
+volumes:
+  postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: mytaskshub-db
+    restart: always
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  backend:
+    image: mytaskshub-backend:prod
+    container_name: mytaskshub-backend
+    restart: always
+    build: 
+      context: ./backend
+      dockerfile: Dockerfile
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      FRONTEND_URL: ${FRONTEND_URL}
+      JWT_SECRET: ${JWT_SECRET}
+      PORT: 3000
+    depends_on:
+      - postgres
+    ports:
+      - "3000:3000"
+
+  frontend:
+    image: mytaskshub-frontend:prod
+    container_name: mytaskshub-frontend
+    restart: always
+    build: 
+      context: ./frontend
+      dockerfile: Dockerfile
+    ports:
+      - "80:80"
+
+volumes:
+  postgres_data:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# Configurações do frontend
+VITE_BACKEND_API_URL="http://localhost:3000/api"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:20-alpine AS builder
+
+WORKDIR /usr/app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+ENV NODE_ENV=production
+
+RUN npm run build
+
+FROM nginx:alpine
+
+RUN rm /etc/nginx/conf.d/default.conf
+
+COPY nginx.conf /etc/nginx/conf.d/
+
+COPY --from=builder /usr/app/dist /usr/share/nginx/html
+
+EXPOSE 80

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,0 +1,17 @@
+FROM node:20-alpine
+
+RUN apk add --no-cache python3 make g++
+
+WORKDIR /usr/app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . ./
+
+ENV NODE_ENV=development
+
+EXPOSE 5173
+
+CMD [ "npm", "run", "dev", "--", "--host", "0.0.0.0" ]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,6 @@
 # Frontend - Hackaton Plataforma de Estudos
 
-Aplicação frontend construída com **React + Vite**, com tema visual **Deep Ocean** e tipografia **Poppins**.
+Aplicação frontend construída com **React + Vite**, com tema visual **Deep Ocean** e tipografia **Poppins**. Assim como o backend, o frontend também possui duas formas de rodar, localmente ou via docker, abaixo tem as instruções de como rodar das duas formas.
 
 ## 📋 Pré-requisitos
 
@@ -8,8 +8,9 @@ Antes de começar, garanta que você tem instalado:
 
 - **Node.js** (recomendado: 18+)
 - **npm** (ou pnpm/yarn)
+- **Docker** (opcional, porém preferível)
 
-## 🚀 Como rodar o frontend
+## 🚀 Como rodar o frontend localmente
 
 1. Entre na pasta do frontend:
 
@@ -25,10 +26,10 @@ npm install
 
 3. Configure as variáveis de ambiente (se ainda não existir):
 
-Crie um arquivo `.env` na raiz do frontend:
+Copie o arquivo `.env.example` e renomeie-o para `.env` na raiz do frontend, abaixo está um exemplo de como devem ficar suas variáveis de ambiente:
 
 ```env
-BACKEND_API_URL=http://localhost:3000/api
+VITE_BACKEND_API_URL=http://localhost:3000/api
 ```
 
 4. Inicie o servidor de desenvolvimento:
@@ -42,6 +43,14 @@ npm run dev
 - `http://localhost:5173`
 
 ---
+
+## 🚀 Como rodar o frontend via docker
+
+Com o docker iniciado, na pasta **`frontend`** digite o comando abaixo no seu terminal:
+
+```bash
+docker-compose up -d
+```
 
 ## 🔧 Comandos principais
 
@@ -81,7 +90,7 @@ Este frontend espera um backend rodando em:
 Se necessário, ajuste no arquivo `.env`:
 
 ```env
-BACKEND_API_URL=http://localhost:3000/api
+VITE_BACKEND_API_URL=http://localhost:3000/api
 ```
 
 ---

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  frontend:
+    image: mytaskshub-frontend:1.0
+    container_name: mytaskshub-frontend
+    environment:
+      - VITE_BACKEND_API_URL=${VITE_BACKEND_API_URL:-http://localhost:3000}
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    volumes:
+       - .:/usr/app           
+       - /usr/app/node_modules 
+    ports:
+      - "5173:5173"

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: mytaskshub-frontend:1.0
     container_name: mytaskshub-frontend
     environment:
-      - VITE_BACKEND_API_URL=${VITE_BACKEND_API_URL:-http://localhost:3000}
+      - VITE_BACKEND_API_URL=${VITE_BACKEND_API_URL:-http://localhost:3000/api}
     build:
       context: .
       dockerfile: Dockerfile.dev

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,16 @@
+server {
+    listen 80;
+
+    server_name localhost;
+
+    location / {
+        root /usr/share/nginx/html;
+        index index.html index.htm;
+
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api {
+        proxy_pass http://mytaskshub-backend:3000;
+    }
+}

--- a/frontend/src/services/apiService.js
+++ b/frontend/src/services/apiService.js
@@ -1,5 +1,5 @@
 const API_BASE_URL =
-  import.meta.env.VITE_BACKEND_API_URL || "http://localhost:3000/api";
+  import.meta.env.VITE_BACKEND_API_URL;
 
 export async function apiRequest(path, options = {}) {
   const jwtToken = localStorage.getItem("token");


### PR DESCRIPTION
# Descrição
Este PR implementa a infraestrutura necessária para rodar o mytaskshub em ambiente de produção utilizando Docker

# 🛠️ Principais Alterações
## 1. Dockerfiles de Produção e Desenvolvimento
**Backend**: Criado Dockerfile focado em produção e desenvolvimento. Removidas as dependências de desenvolvimento (ex: nodemon) usando `ENV NODE_ENV=production` antes do `npm install`.

**Frontend**: Implementado um Multi-Stage Build. O primeiro estágio usa o Node para compilar o código JSX/Vite (`npm run build`). O segundo estágio descarta todo o Node e usa apenas uma imagem do Nginx para servir os arquivos estáticos (HTML/CSS/JS).

## 2. Introdução do Nginx como Reverse Proxy
Adicionado o arquivo nginx.conf no frontend.
O Nginx agora atua como a porta de entrada (porta 80). Ele entrega os arquivos do **frontend** e, ao receber requisições em `/api`, faz um proxy interno redirecionando silenciosamente para o container do **backend** na porta 3000. Isso elimina problemas de CORS no navegador do usuário final.

## 3. Correção das  Variáveis de Ambiente do Vite
**Problema**: O Vite não lê variáveis do sistema operacional em tempo de execução. Ele as injeta estaticamente no momento do build.

**Solução**: A variável `VITE_BACKEND_API_URL` foi movida para um arquivo `.env` dentro da pasta **frontend/**. Isso garante que no momento de build o valor da variável `VITE_BACKEND_API_URL` seja sempre capturada com o valor correto (/api) e evitando bugs de rota.

### 🚀 Como testar localmente o modo de produção
Certifique-se de que o arquivo `.env` (com as credenciais do banco e do JWT) está na raiz do projeto.
Certifique-se de que existe um arquivo `.env` dentro da pasta **frontend/** contendo apenas: VITE_BACKEND_API_URL=/api
Rode o comando para subir o ambiente de produção:
```bash
docker-compose up -d --build
```
Como o banco sobe limpo, garanta que as tabelas foram criadas rodando:
```bash
docker exec -it mytaskshub-backend npx prisma db push
```
Acesse http://localhost no navegador. O frontend deve carregar e as requisições de cadastro/login devem bater no backend corretamente pela rota /api.